### PR TITLE
Fix missing duration utility

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,16 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.
+
+interface ImportMetaEnv {
+  readonly NEXT_PUBLIC_SUPABASE_URL: string
+  readonly NEXT_PUBLIC_SUPABASE_ANON_KEY: string
+  readonly SUPABASE_SERVICE_ROLE_KEY: string
+  readonly OPENAI_API_KEY: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/utils/format-duration.ts
+++ b/utils/format-duration.ts
@@ -1,0 +1,14 @@
+export function formatDuration(totalSeconds: number): string {
+  const hours = Math.floor(totalSeconds / 3600)
+  const minutes = Math.floor((totalSeconds % 3600) / 60)
+  const seconds = totalSeconds % 60
+
+  const parts = []
+  if (hours > 0) {
+    parts.push(String(hours).padStart(2, '0'))
+  }
+  parts.push(String(minutes).padStart(2, '0'))
+  parts.push(String(seconds).padStart(2, '0'))
+
+  return parts.join(':')
+}


### PR DESCRIPTION
## Summary
- add `formatDuration` helper and Next.js type env

## Testing
- `npm run lint` *(fails: prompts for config)*
- `npx tsc --noEmit` *(fails: several type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6848785b136c832f8ed25ad85985ab57