### PR TITLE
Fix manifest description

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "HandwerksZeit",
   "short_name": "HandwerksZeit",
-  "description": "Baustellen Dokumentation App",
+  "description": "Baustellendokumentation App",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#ffffff",


### PR DESCRIPTION
## Summary
- update the manifest description to use the compound German word "Baustellendokumentation"

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68487a281508832f8899deabbefd54e3