### PR TITLE
Fix TODO wording about entry loading

### DIFF
--- a/components/tasks/task-form.tsx
+++ b/components/tasks/task-form.tsx
@@ -67,7 +67,7 @@ export function TaskForm({ defaultProjectId, defaultEntryId, onSuccess }: TaskFo
     loadData()
   }, [])
 
-  // TODO: Lade Einträge, wenn sich Projekt ändert (für Eintragsauswahl)
+  // TODO: Einträge laden, wenn sich das Projekt ändert (zukünftige Erweiterung)
 
   const onSubmit: SubmitHandler<TaskFormData> = async (data) => {
     setIsLoading(true)


### PR DESCRIPTION
## Summary
- clarify entry loading is a planned feature in `task-form.tsx`

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68487a2be694832f8a1ce09b57f484c8