### PR TITLE
Add task permission checks

### DIFF
--- a/app/tasks/actions.ts
+++ b/app/tasks/actions.ts
@@ -85,7 +85,25 @@ export async function updateTaskStatus(
   const profile = await getUserProfile() // Für Berechtigungsprüfung
   if (!profile) return { success: false, error: "Benutzer nicht authentifiziert." }
 
-  // TODO: Berechtigungsprüfung, ob der Benutzer den Status ändern darf (Autor, Empfänger, Admin)
+  // Berechtigungsprüfung
+  const { data: existingTask, error: fetchError } = await supabase
+    .from("comments")
+    .select("author_id, recipient_ids")
+    .eq("id", id)
+    .single()
+
+  if (fetchError || !existingTask) {
+    console.error("Error fetching task for status update:", fetchError)
+    return { success: false, error: "Aufgabe nicht gefunden." }
+  }
+
+  const isAuthor = existingTask.author_id === profile.id
+  const isRecipient = existingTask.recipient_ids?.includes(profile.id)
+  const isAdmin = profile.role === "admin"
+
+  if (!isAuthor && !isRecipient && !isAdmin) {
+    return { success: false, error: "Keine Berechtigung, den Status zu ändern." }
+  }
 
   const { data, error } = await supabase
     .from("comments")
@@ -107,7 +125,24 @@ export async function deleteTask(id: string): Promise<{ success: boolean; error?
   const profile = await getUserProfile()
   if (!profile) return { success: false, error: "Benutzer nicht authentifiziert." }
 
-  // TODO: Berechtigungsprüfung (Autor oder Admin)
+  // Berechtigungsprüfung
+  const { data: existingTask, error: fetchError } = await supabase
+    .from("comments")
+    .select("author_id")
+    .eq("id", id)
+    .single()
+
+  if (fetchError || !existingTask) {
+    console.error("Error fetching task for delete:", fetchError)
+    return { success: false, error: "Aufgabe nicht gefunden." }
+  }
+
+  const isAuthor = existingTask.author_id === profile.id
+  const isAdmin = profile.role === "admin"
+
+  if (!isAuthor && !isAdmin) {
+    return { success: false, error: "Keine Berechtigung, diese Aufgabe zu löschen." }
+  }
 
   const { error } = await supabase.from("comments").delete().eq("id", id)
   if (error) {


### PR DESCRIPTION
## Summary
- verify author/recipient/admin before updating task status
- verify author/admin before deleting a task

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6849da5715b4832f864a483f3667c6fc