### PR TITLE
Expand materials and receipts features

### DIFF
--- a/app/materials/inventory/page.tsx
+++ b/app/materials/inventory/page.tsx
@@ -1,0 +1,21 @@
+import { MainLayout } from "@/components/layout/main-layout"
+import { MaterialInventory } from "@/components/materials/material-inventory"
+import { createSupabaseServerClient } from "@/lib/supabase/server"
+import { redirect } from "next/navigation"
+
+export default async function MaterialInventoryPage() {
+  const supabase = createSupabaseServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect("/login")
+  }
+
+  return (
+    <MainLayout>
+      <MaterialInventory />
+    </MainLayout>
+  )
+}

--- a/components/layout/enhanced-sidebar.tsx
+++ b/components/layout/enhanced-sidebar.tsx
@@ -48,6 +48,12 @@ const menuItems = [
     badge: null,
   },
   {
+    title: "Bestand",
+    icon: Package,
+    href: "/materials/inventory",
+    badge: null,
+  },
+  {
     title: "Belege",
     icon: Receipt,
     href: "/receipts",

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -32,6 +32,11 @@ const menuItems = [
     icon: Package,
   },
   {
+    title: "Bestand",
+    href: "/materials/inventory",
+    icon: Package,
+  },
+  {
     title: "Belege",
     href: "/receipts",
     icon: Receipt,

--- a/components/receipts/receipt-form.tsx
+++ b/components/receipts/receipt-form.tsx
@@ -21,7 +21,13 @@ import type { Database } from "@/lib/supabase/database.types"
 
 type Project = Database["public"]["Tables"]["projects"]["Row"]
 
-const receiptCategories = ["Tankquittung", "Material Barzahlung", "Werkzeug", "Verpflegung", "Sonstiges"]
+export const receiptCategories = [
+  "Tankquittung",
+  "Material Barzahlung",
+  "Werkzeug",
+  "Verpflegung",
+  "Sonstiges",
+]
 
 const receiptSchema = z.object({
   receipt_date: z.string().min(1, "Datum ist erforderlich."),


### PR DESCRIPTION
## Summary
- export `receiptCategories` for reuse
- add filtering options (category, project, date range) to receipt list
- add MaterialInventory page and link in sidebars

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b29c98cf4832faf54a37d463a84b2