### PR TITLE
Finalize project CRUD and export page

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Eine moderne, KI-gestützte Web-Anwendung zur digitalen Dokumentation und Verwal
 - **👥 Benutzerverwaltung** - Admin-Panel für Benutzer und Gruppen
 - **🌓 Dark/Light Mode** - Umschaltbare Themes
 - **📱 Responsive Design** - Optimiert für Desktop und Mobile
+- **🏗️ Baustellen-Management** - Verwaltung von Projekten und Baustellen
 
 ### 🚧 In Entwicklung
-- **🏗️ Baustellen-Management** - Verwaltung von Projekten und Baustellen
 - **📦 Materialverwaltung** - Erfassung und Verwaltung verwendeter Materialien
 - **🧾 Belegverwaltung** - Digitale Quittungs- und Rechnungsverwaltung
 - **👥 Kundenverwaltung** - Zentrale Kundendatenbank
@@ -29,7 +29,7 @@ Eine moderne, KI-gestützte Web-Anwendung zur digitalen Dokumentation und Verwal
 - **🖼️ Galerie** - Zentrale Bildübersicht
 - **📱 PWA** - Progressive Web App Funktionalität
 - **🔄 Offline-Modus** - Arbeiten ohne Internetverbindung
-- **📤 Export-Funktionen** - PDF, Excel Export
+- **📤 Export-Funktionen** - CSV-Export verfügbar, PDF/Excel geplant
 - **🔔 Push-Benachrichtigungen** - Echtzeit-Updates
 
 ## 🛠️ Tech Stack
@@ -288,7 +288,7 @@ Dieses Projekt steht unter der MIT Lizenz. Siehe [LICENSE](LICENSE) Datei für D
 - ✅ Benutzerauthentifizierung
 - ✅ Sprachsteuerung
 - ✅ Vollständige Zeiterfassung
-- 🚧 Baustellen-Management
+- ✅ Baustellen-Management
 - 🚧 Materialverwaltung
 
 ### Version 1.1 (Q2 2024)
@@ -299,7 +299,7 @@ Dieses Projekt steht unter der MIT Lizenz. Siehe [LICENSE](LICENSE) Datei für D
 
 ### Version 1.2 (Q3 2024)
 - 📋 Rechnungsstellung
-- 📋 Export-Funktionen
+- 📋 Export-Funktionen (PDF/Excel)
 - 📋 Team-Kollaboration
 - 📋 API für Drittanbieter
 

--- a/app/baustellen/export/page.tsx
+++ b/app/baustellen/export/page.tsx
@@ -1,0 +1,36 @@
+import { MainLayout } from "@/components/layout/main-layout"
+import { getBaustellen } from "../actions"
+import { ExportDialog } from "@/components/baustellen/export-dialog"
+
+export default async function ExportPage() {
+  const result = await getBaustellen()
+  const baustellen = result.data || []
+
+  return (
+    <MainLayout>
+      <div className="container mx-auto py-8 space-y-4">
+        <h1 className="text-2xl font-semibold">Baustellen exportieren</h1>
+        {baustellen.length > 0 ? (
+          <div className="space-y-4">
+            {baustellen.map((b) => (
+              <div
+                key={b.id}
+                className="flex items-center justify-between border rounded-lg p-4"
+              >
+                <div>
+                  <p className="font-medium">{b.name}</p>
+                  {b.address && (
+                    <p className="text-sm text-muted-foreground">{b.address}</p>
+                  )}
+                </div>
+                <ExportDialog projectId={b.id} projectName={b.name} />
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="text-muted-foreground">Keine Baustellen gefunden.</p>
+        )}
+      </div>
+    </MainLayout>
+  )
+}

--- a/components/layout/enhanced-sidebar.tsx
+++ b/components/layout/enhanced-sidebar.tsx
@@ -18,6 +18,7 @@ import {
   Settings,
   Calendar,
   BarChart3,
+  FileDown,
   Euro,
   LogOut,
 } from "lucide-react"
@@ -39,6 +40,12 @@ const menuItems = [
     title: "Baustellen",
     icon: Building,
     href: "/baustellen",
+    badge: null,
+  },
+  {
+    title: "Export",
+    icon: FileDown,
+    href: "/baustellen/export",
     badge: null,
   },
   {

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -6,7 +6,7 @@ import { usePathname } from "next/navigation"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
-import { Home, Clock, Building, Package, Receipt, Users, Settings, Menu, X, Calendar, BarChart3 } from "lucide-react"
+import { Home, Clock, Building, Package, Receipt, Users, Settings, Menu, X, Calendar, BarChart3, FileDown } from "lucide-react"
 import { useMobile } from "@/hooks/use-mobile"
 import { motion, AnimatePresence } from "framer-motion"
 
@@ -25,6 +25,11 @@ const menuItems = [
     title: "Baustellen",
     href: "/baustellen",
     icon: Building,
+  },
+  {
+    title: "Export",
+    href: "/baustellen/export",
+    icon: FileDown,
   },
   {
     title: "Materialien",

--- a/components/projects/project-list-admin-view.tsx
+++ b/components/projects/project-list-admin-view.tsx
@@ -3,7 +3,12 @@
 import { Card } from "@/components/ui/card"
 
 import { useState, useEffect } from "react"
-import { getProjects, deleteProject } from "@/app/projects/actions"
+import {
+  getProjects,
+  deleteProject,
+  createProject,
+  updateProject,
+} from "@/app/projects/actions"
 import type { Database } from "@/lib/supabase/database.types"
 import { Button } from "@/components/ui/button"
 import { PlusCircle, Edit, Trash2, Search, Loader2 } from "lucide-react"
@@ -58,6 +63,41 @@ export function ProjectListAdminView() {
     setIsFormOpen(false)
     setSelectedProject(null)
     fetchProjects() // Daten neu laden
+  }
+
+  const handleFormSubmit = async (
+    data: Pick<Project, "name" | "address" | "description">,
+    isUpdate?: boolean,
+  ) => {
+    setIsLoading(true)
+    try {
+      const result = isUpdate && selectedProject
+        ? await updateProject(selectedProject.id, data)
+        : await createProject(data)
+
+      if (result.success) {
+        toast({
+          title: "Erfolg",
+          description: `Projekt wurde ${isUpdate ? "aktualisiert" : "erstellt"}.`,
+        })
+        handleFormSuccess()
+      } else {
+        toast({
+          title: "Fehler",
+          description: result.error || "Aktion fehlgeschlagen",
+          variant: "destructive",
+        })
+      }
+    } catch (e) {
+      console.error(e)
+      toast({
+        title: "Fehler",
+        description: "Aktion fehlgeschlagen",
+        variant: "destructive",
+      })
+    } finally {
+      setIsLoading(false)
+    }
   }
 
   const openEditForm = (project: Project) => {
@@ -188,7 +228,11 @@ export function ProjectListAdminView() {
       <Dialog open={isFormOpen} onOpenChange={setIsFormOpen}>
         <DialogContent className="sm:max-w-lg">
           <DialogHeader>{/* Titel wird in ProjectForm gesetzt */}</DialogHeader>
-          <ProjectForm project={selectedProject} onSuccess={handleFormSuccess} />
+          <ProjectForm
+            project={selectedProject}
+            onSuccess={handleFormSuccess}
+            onSubmit={handleFormSubmit}
+          />
         </DialogContent>
       </Dialog>
 


### PR DESCRIPTION
## Summary
- wire project form actions to Supabase
- add dedicated page to export Baustellen data
- link export page from sidebars
- document project management and CSV export in README

## Testing
- `npm test` *(fails: playwright not found)*
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684c7be82034832fa4f649cc62638f37