### PR TITLE
Add type-check script

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,12 @@ Eine moderne, KI-gestützte Web-Anwendung zur digitalen Dokumentation und Verwal
    - `receiptimages` (public) - Für Belege
    - `documents` (public) - Für Dokumente
 
-6. **Entwicklungsserver starten**
+6. **TypeScript Typen prüfen**
+\`\`\`bash
+npm run type-check
+\`\`\`
+
+7. **Entwicklungsserver starten**
    \`\`\`bash
    npm run dev
    # oder

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "playwright test"
+    "test": "playwright test",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "@emotion/is-prop-valid": "latest",


### PR DESCRIPTION
## Zusammenfassung
- `npm run type-check` Script in `package.json` ergänzt
- README beschreibt nun die Ausführung der Typprüfung vor dem Start des Dev-Servers

## Testing
- `npm run type-check` *(fehlschlagend)*
- `npm test` *(fehlschlagend)*

------
https://chatgpt.com/codex/tasks/task_e_684e02d16958832fa45d5e2610cdf2db