### PR TITLE
Add export dialog test and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 8
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+      - name: Run tests
+        run: npm test

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "playwright test"
+    "test": "NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=anon SUPABASE_SERVICE_ROLE_KEY=service playwright test"
   },
   "dependencies": {
     "@emotion/is-prop-valid": "latest",

--- a/tests/export.spec.ts
+++ b/tests/export.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect, Page } from '@playwright/test'
+
+async function mockExport(page: Page) {
+  await page.addInitScript(() => {
+    const originalFetch = window.fetch
+    window.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (typeof input === 'string' && input.includes('/baustellen/export') && init?.method === 'POST') {
+        const body = JSON.stringify({ success: true, data: 'col1,col2\n', filename: 'data.csv' })
+        return new Response(body, { status: 200, headers: { 'Content-Type': 'application/json' } }) as any
+      }
+      return originalFetch(input, init)
+    }
+  })
+}
+
+test('Export-Dialog lädt CSV herunter', async ({ page }) => {
+  await mockExport(page)
+  await page.goto('/baustellen/export')
+  await page.getByRole('button', { name: 'Exportieren' }).first().click()
+  await expect(page.getByText('Baustelle exportieren')).toBeVisible()
+  const [download] = await Promise.all([
+    page.waitForEvent('download'),
+    page.getByRole('button', { name: 'Exportieren' }).last().click(),
+  ])
+  expect(download.suggestedFilename()).toBe('data.csv')
+})


### PR DESCRIPTION
## Summary
- add a Playwright test for the ExportDialog
- create GitHub Actions workflow to run tests automatically
- expose dummy Supabase env vars for running tests

## Testing
- `npm test` *(fails: timeout in export and login tests)*

------
https://chatgpt.com/codex/tasks/task_e_684e02de61b8832fba8e40c72aa07d2d