### PR TITLE
mock anchor click in export dialog test

### DIFF
--- a/tests/export-dialog.test.tsx
+++ b/tests/export-dialog.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { vi } from "vitest"
+import { ExportDialog } from "@/components/baustellen/export-dialog"
+import * as actions from "@/app/baustellen/export/actions"
+
+describe("ExportDialog", () => {
+  it("ruft exportBaustellenData beim Klick auf Exportieren auf", async () => {
+    const mockExport = vi
+      .spyOn(actions, "exportBaustellenData")
+      .mockResolvedValue({ success: true, data: "", filename: "test.csv" })
+
+    render(<ExportDialog projectId="1" projectName="Test" />)
+
+    // Dialog öffnen
+    const trigger = screen.getByRole("button", { name: /Exportieren/i })
+    await userEvent.click(trigger)
+
+    // Klick auf Anker-Element verhindern
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {})
+
+    // Export-Button klicken
+    const exportButton = screen.getAllByRole("button", { name: /Exportieren/i })[1]
+    await userEvent.click(exportButton)
+
+    expect(mockExport).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- add unit test for the export dialog
- mock HTMLAnchorElement click to prevent navigation

## Testing
- *no tests run due to environment restrictions*


------
https://chatgpt.com/codex/tasks/task_e_684eb0bb3f78832fa5c60b7969b6bdb4